### PR TITLE
Make PHP8 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,12 @@
     "homepage": "http://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=5.2.1"
+        "php": "^8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "squizlabs/php_codesniffer": "~2.3"
+        "squizlabs/php_codesniffer": "~2.3",
+        "rector/rector": "^2.1"
     },
     "autoload": {
         "files": ["src/Google/autoload.php"]

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector;
 
@@ -13,7 +14,7 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     // ->withPhpSets()
-    ->withRules([CurlyToSquareBracketArrayStringRector::class])
+    ->withRules([CurlyToSquareBracketArrayStringRector::class, ConsistentImplodeRector::class])
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -12,6 +13,7 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     // ->withPhpSets()
+    ->withRules([CurlyToSquareBracketArrayStringRector::class])
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -542,7 +542,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
 
     // Check signature
     $verified = false;
-    foreach ($certs as $keyName => $pem) {
+    foreach ($certs as $pem) {
       $public_key = new Google_Verifier_Pem($pem);
       if ($public_key->verify($signed, $signature)) {
         $verified = true;

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -389,7 +389,7 @@ class Google_Client
   public function setRequestVisibleActions($requestVisibleActions)
   {
     if (is_array($requestVisibleActions)) {
-      $requestVisibleActions = join(" ", $requestVisibleActions);
+      $requestVisibleActions = implode(" ", $requestVisibleActions);
     }
     $this->config->setRequestVisibleActions($requestVisibleActions);
   }

--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -170,7 +170,7 @@ class Google_Http_REST
     }
 
     if (count($queryVars)) {
-      $requestUrl .= '?' . implode($queryVars, '&');
+      $requestUrl .= '?' . implode('&', $queryVars);
     }
 
     return $requestUrl;

--- a/src/Google/Utils.php
+++ b/src/Google/Utils.php
@@ -62,7 +62,7 @@ class Google_Utils
     $strlenVar = strlen($str);
     $d = $ret = 0;
     for ($count = 0; $count < $strlenVar; ++ $count) {
-      $ordinalValue = ord($str{$ret});
+      $ordinalValue = ord($str[$ret]);
       switch (true) {
         case (($ordinalValue >= 0x20) && ($ordinalValue <= 0x7F)):
           // characters U-00000000 - U-0000007F (same as ASCII)

--- a/tests/general/AuthTest.php
+++ b/tests/general/AuthTest.php
@@ -225,7 +225,7 @@ PK;
           "exp" => time() + 3600
         )
     );
-    $id_token = $id_token . "a";
+    $id_token .= "a";
     $this->checkIdTokenFailure($id_token, "Invalid token signature");
   }
 

--- a/tests/general/IoTest.php
+++ b/tests/general/IoTest.php
@@ -299,20 +299,20 @@ class IoTest extends BaseTest
 
     $rawResponse = "$rawHeaders\r\n$rawBody";
     list($headers, $body) = $io->parseHttpResponse($rawResponse, $size);
-    $this->assertEquals(3, sizeof($headers));
+    $this->assertEquals(3, count($headers));
     $this->assertEquals(array(), json_decode($body, true));
 
     // Test empty bodies.
     $rawResponse = $rawHeaders . "\r\n";
     list($headers, $body) = $io->parseHttpResponse($rawResponse, $size);
-    $this->assertEquals(3, sizeof($headers));
+    $this->assertEquals(3, count($headers));
     $this->assertEquals(null, json_decode($body, true));
 
     // Test no content.
     $rawerHeaders = "HTTP/1.1 204 No Content\r\n"
       . "Date: Fri, 19 Sep 2014 15:52:14 GMT";
     list($headers, $body) = $io->parseHttpResponse($rawerHeaders, 0);
-    $this->assertEquals(1, sizeof($headers));
+    $this->assertEquals(1, count($headers));
     $this->assertEquals(null, json_decode($body, true));
 
     // Test transforms from proxies.
@@ -332,7 +332,7 @@ class IoTest extends BaseTest
 
       $rawResponse = "$rawHeaders\r\n$rawBody";
       list($headers, $body) = $io->parseHttpResponse($rawResponse, $headersSize);
-      $this->assertEquals(1, sizeof($headers));
+      $this->assertEquals(1, count($headers));
       $this->assertEquals(array(), json_decode($body, true));
     }
   }

--- a/tests/tasks/TasksTest.php
+++ b/tests/tasks/TasksTest.php
@@ -62,7 +62,7 @@ class TasksTest extends BaseTest
     }
 
     $tasksArray = $tasks->listTasks($list['id']);
-    $this->assertTrue(sizeof($tasksArray) > 1);
+    $this->assertTrue(count($tasksArray) > 1);
     foreach ($tasksArray['items'] as $task) {
       $this->assertIsTask($task);
     }


### PR DESCRIPTION
Runs two Rector rules (CurlyToSquareBracketArrayStringRector and ConsistentImplodeRector) to make this version PHP8 compatible.